### PR TITLE
Truncate errors to 50,000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Keeps tracks of the versions of `nacc-file-validator`
 
+## 0.3.4
+
+* Truncates errors to 50,000 to avoid BSON limit
+
 ## 0.3.3
 
 * Re-syncs with Flywheel

--- a/fw_gear_file_validator/errors.py
+++ b/fw_gear_file_validator/errors.py
@@ -20,6 +20,7 @@ log = logging.getLogger(__name__)
 TIMEFORMAT = "%Y-%m-%d %H:%M:%S"
 RUNTIME = datetime.now()
 TIMESTAMP = RUNTIME.strftime(TIMEFORMAT)
+MAX_ERRORS = 50_000
 
 
 class FileError(BaseModel):
@@ -162,7 +163,7 @@ def make_malformed_file_error() -> ValidationError:
     be able to properly parse every line.
 
     Returns:
-        ValidationError with validator = "unknown-field"
+        ValidationError with validator = "malformed-file"
 
     """
     return ValidationError(
@@ -175,6 +176,28 @@ def make_malformed_file_error() -> ValidationError:
             "path": "",
         }
     )
+
+
+def make_too_many_errors_error() -> dict:
+    """Makes an error for a csv file that needed its errors truncated due to hitting
+    maximum limit.
+
+    Returns:
+        Serialized too-many-errors ValidationError
+
+    """
+    error = ValidationError(
+        **{
+            "validator": "too-many-errors",
+            "schema_path": [""],
+            "instance": "",
+            "schema": "",
+            "message": f"This file had too many errors and had to be truncated (max {MAX_ERRORS}).",
+            "path": "",
+        }
+    )
+
+    return validator_error_to_standard(error)
 
 
 def make_bad_file_error() -> ValidationError:
@@ -230,6 +253,12 @@ def save_errors_metadata(
         meta_dict = {}
     else:
         state = "FAIL"
+        """There is a BSON limit of 22699725 bytes, so cap out error list at 50k."""
+        if len(errors) > MAX_ERRORS:
+            log.warning(f"Errors list too large, truncating to {MAX_ERRORS}")
+            errors = errors[0:MAX_ERRORS]
+            errors.append(make_too_many_errors_error())
+
         meta_dict = {"data": errors}
 
     gtk_context.metadata.add_qc_result(

--- a/fw_gear_file_validator/errors.py
+++ b/fw_gear_file_validator/errors.py
@@ -253,7 +253,7 @@ def save_errors_metadata(
         meta_dict = {}
     else:
         state = "FAIL"
-        """There is a BSON limit of 22699725 bytes, so cap out error list at 50k."""
+        """There is a BSON limit of 16793598 bytes, so cap out error list at 50k."""
         if len(errors) > MAX_ERRORS:
             log.warning(f"Errors list too large, truncating to {MAX_ERRORS}")
             errors = errors[0:MAX_ERRORS]

--- a/manifest.json
+++ b/manifest.json
@@ -57,7 +57,7 @@
     },
     "gear-builder": {
       "category": "qa",
-      "image": "flywheel/nacc-file-validator:0.3.4a"
+      "image": "flywheel/nacc-file-validator:0.3.4"
     }
   },
   "description": "Validates a file based on a provided validation schema",
@@ -90,5 +90,5 @@
   "name": "nacc-file-validator",
   "source": "https://github.com/naccdata/nacc-file-validator.git",
   "url": "https://github.com/naccdata/nacc-file-validator.git",
-  "version": "0.3.4a"
+  "version": "0.3.4"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -57,7 +57,7 @@
     },
     "gear-builder": {
       "category": "qa",
-      "image": "flywheel/file-validator:0.3.3"
+      "image": "flywheel/nacc-file-validator:0.3.4a"
     }
   },
   "description": "Validates a file based on a provided validation schema",
@@ -84,11 +84,11 @@
       "description": "The schema to use to validate the file"
     }
   },
-  "label": "File Validator",
+  "label": "NACC File Validator",
   "license": "Other",
   "maintainer": "Flywheel <support@flywheel.io>",
-  "name": "file-validator",
-  "source": "https://gitlab.com/flywheel-io/scientific-solutions/gears/file-validator.git",
-  "url": "https://gitlab.com/flywheel-io/scientific-solutions/gears/file-validator.git",
-  "version": "0.3.3"
+  "name": "nacc-file-validator",
+  "source": "https://github.com/naccdata/nacc-file-validator.git",
+  "url": "https://github.com/naccdata/nacc-file-validator.git",
+  "version": "0.3.4a"
 }


### PR DESCRIPTION
There is a 16793598 BSON upload limit, so truncate errors to 50,000. Looks like this in the Issue Manager:

![image](https://github.com/user-attachments/assets/bbc771c5-bf51-4b3a-8e4c-71b13055f257)

